### PR TITLE
ClangImporter: default to ios objc runtime on non-darwin platforms

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -464,11 +464,14 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       SHIMS_INCLUDE_FLAG, searchPathOpts.RuntimeResourcePath,
   });
 
-  if (LangOpts.EnableObjCInterop)
+  if (LangOpts.EnableObjCInterop) {
     invocationArgStrs.insert(invocationArgStrs.end(),
                              {"-x", "objective-c", "-std=gnu11", "-fobjc-arc"});
-  else
+    if (!triple.isOSDarwin())
+      invocationArgStrs.insert(invocationArgStrs.end(), {"-fobjc-runtime=ios"});
+  } else {
     invocationArgStrs.insert(invocationArgStrs.end(), {"-x", "c", "-std=gnu11"});
+  }
 
   // Get the version of this compiler and pass it to C/Objective-C declarations.
   auto V = version::Version::getCurrentCompilerVersion();


### PR DESCRIPTION
This allows objc interop to be tested on non-darwin platforms. The iOS
runtime is used because the abi is the same as the macOS abi, but without
fragility concerns.

<!-- This selection should only be completed by Swift admin -->
Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>Triggering Swift CI</summary>

The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

        Platform     | Comment
        ------------ | -------------
        All supported platforms     | @swift-ci Please smoke test
        OS X platform               | @swift-ci Please smoke test OS X platform
        Linux platform              | @swift-ci Please smoke test Linux platform

 **Validation Testing**

        Platform     | Comment
        ------------ | -------------
        All supported platforms     | @swift-ci Please test
        OS X platform               | @swift-ci Please test OS X platform
        Linux platform              | @swift-ci Please test Linux platform

Note: Only members of the Apple organization can trigger swift-ci.
</details>
<!-- Thank you for your contribution to Swift! -->
